### PR TITLE
Update to the azapi resource in subnet-vm to use latest version of azapi

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -33,7 +33,7 @@ resource "azapi_resource" "subnet-vm" {
   name      = "${azurerm_virtual_network.vnet.name}-vm-snet"
   parent_id = azurerm_virtual_network.vnet.id
 
-  body = jsonencode({
+  body = {
     properties = {
       addressPrefixes       = [cidrsubnet(var.base_cidr_space, 8, 3)]
       defaultOutboundAccess = false
@@ -45,7 +45,7 @@ resource "azapi_resource" "subnet-vm" {
       #   }
       # ]
     }
-  })
+  }
   schema_validation_enabled = false
 
   depends_on = [


### PR DESCRIPTION
This failed due to the azapi resource has recently been updated to version 2 and no longer requires to jsonencode the properties.

I have updated the code to allow this to continue to work.